### PR TITLE
Add dark mode with toggle

### DIFF
--- a/src/components/Template/Navigation.js
+++ b/src/components/Template/Navigation.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 
 import Hamburger from './Hamburger';
+import ThemeToggle from './ThemeToggle';
 import routes from '../../data/routes';
 
 // Websites Navbar, displays routes defined in 'src/data/routes'
@@ -27,6 +28,7 @@ const Navigation = () => (
           ))}
       </ul>
     </nav>
+    <ThemeToggle />
     <Hamburger />
   </header>
 );

--- a/src/components/Template/ThemeToggle.js
+++ b/src/components/Template/ThemeToggle.js
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faMoon, faSun } from '@fortawesome/free-solid-svg-icons';
+
+const ThemeToggle = () => {
+  const [theme, setTheme] = useState('light');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme');
+    const preferredDark = window.matchMedia
+      && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const initial = stored || (preferredDark ? 'dark' : 'light');
+    setTheme(initial);
+    document.body.classList.toggle('dark', initial === 'dark');
+  }, []);
+
+  const toggle = () => {
+    const next = theme === 'dark' ? 'light' : 'dark';
+    document.body.classList.toggle('dark', next === 'dark');
+    localStorage.setItem('theme', next);
+    setTheme(next);
+  };
+
+  return (
+    <button
+      type="button"
+      className="theme-toggle menu-hover"
+      aria-label="Toggle dark mode"
+      onClick={toggle}
+    >
+      <FontAwesomeIcon icon={theme === 'dark' ? faSun : faMoon} />
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/src/static/css/components/_theme-toggle.scss
+++ b/src/static/css/components/_theme-toggle.scss
@@ -1,0 +1,12 @@
+.theme-toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.2em;
+  padding: 0 1em;
+  color: inherit;
+}
+
+.theme-toggle:hover {
+  opacity: 0.5;
+}

--- a/src/static/css/components/_theme-toggle.scss
+++ b/src/static/css/components/_theme-toggle.scss
@@ -1,5 +1,6 @@
 .theme-toggle {
   background: none;
+  background-color: transparent;
   border: none;
   cursor: pointer;
   font-size: 1.2em;

--- a/src/static/css/main.scss
+++ b/src/static/css/main.scss
@@ -54,6 +54,7 @@
 @import "components/section";
 @import "components/table";
 @import "components/hamburger";
+@import "components/theme-toggle";
 @import "components/markdown";
 
 // Layout.
@@ -71,3 +72,5 @@
 @import "pages/resume";
 @import "pages/skills";
 @import "pages/stats";
+
+@import "themes/dark";

--- a/src/static/css/themes/_dark.scss
+++ b/src/static/css/themes/_dark.scss
@@ -1,6 +1,10 @@
 body.dark {
   background: #121212;
-  color: #e4e4e4;
+  color: #e8e8e8;
+}
+
+body.dark p {
+  line-height: 1.8;
 }
 
 body.dark a {
@@ -11,15 +15,63 @@ body.dark a:hover {
   color: #a6c4ff !important;
 }
 
+body.dark a:visited {
+  color: #b39ddb;
+}
+
 body.dark #header,
 body.dark #sidebar > *,
 body.dark .post,
 body.dark .bm-menu {
-  background-color: #1e1e1e;
-  border-color: #333;
+  background-color: #1a1a1a;
+  border-color: #444;
 }
 
 body.dark .button {
-  color: #e4e4e4 !important;
-  box-shadow: inset 0 0 0 1px #333;
+  color: #e8e8e8 !important;
+  box-shadow: inset 0 0 0 1px #555;
+}
+
+body.dark .button:hover {
+  box-shadow: inset 0 0 0 1px #82aaff;
+  color: #82aaff !important;
+}
+
+body.dark header p {
+  color: #ccc;
+}
+
+body.dark hr,
+body.dark #sidebar > *,
+body.dark .post {
+  border-color: #444;
+}
+
+body.dark #header a,
+body.dark nav.links a {
+  color: #f0f0f0;
+}
+
+body.dark #header .links li {
+  border-left-color: #444;
+}
+
+body.dark ul.icons a {
+  color: #bbb;
+}
+
+body.dark ul.icons a:hover {
+  color: #82aaff;
+}
+
+body.dark :focus-visible {
+  outline-color: #82aaff;
+}
+
+body.dark section {
+  padding-bottom: 2em;
+}
+
+body.dark #intro .logo img {
+  background-color: #1a1a1a;
 }

--- a/src/static/css/themes/_dark.scss
+++ b/src/static/css/themes/_dark.scss
@@ -1,0 +1,25 @@
+body.dark {
+  background: #121212;
+  color: #e4e4e4;
+}
+
+body.dark a {
+  color: #82aaff;
+}
+
+body.dark a:hover {
+  color: #a6c4ff !important;
+}
+
+body.dark #header,
+body.dark #sidebar > *,
+body.dark .post,
+body.dark .bm-menu {
+  background-color: #1e1e1e;
+  border-color: #333;
+}
+
+body.dark .button {
+  color: #e4e4e4 !important;
+  box-shadow: inset 0 0 0 1px #333;
+}


### PR DESCRIPTION
## Summary
- implement `ThemeToggle` component with FontAwesome icons
- integrate toggle in navigation
- style toggle button and dark theme

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684011b651688320a0f8f8f3f63539c7